### PR TITLE
feat: add Chembench corpus table

### DIFF
--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -49,6 +49,86 @@ A substantial fraction, in contrast to other benchmarks, is open-ended.
     \script{plot_statistics.py}
 \end{figure}
 
+The corpus of the questions in Chembench, as shown in \Cref{tab:chembench_corpus}, can be divided according to which topic they belong, or which type of knowledge is required in order to solve them correctly.
+
+\begin{table*}[!t]
+    \centering
+        \caption{Summary of ChemBench question types.
+    }
+    \begin{tabular}{p{2.7cm}cp{10cm}}
+        \toprule
+        \textbf{Question Type} & \textbf{\%} & \textbf{Example Questions}  \\ 
+        \midrule
+        Chemical Preference & 35.0 & Imagine an early virtual screening campaign setting (accounting for simple aspects such as oral availability and small molecular profile, but no other modalities such as covalency or bifunctionality). Which of the following two candidates would you prefer for further development? \\
+        & & A. [START_SMILES]N#Cc1ccc(OCCCN2CC3CN(CCNS(=O)(=O)c4ccc(F)cc4)CC(C2)O3)cc1[END_SMILES] \\
+        & & B. [START_SMILES]O=C1CC(c2ccc(CC(NS(=O)(=O)c3cc(Cl)cc(Cl)c3)c3nc4ccccc4[nH]3)cc2)S(=O)(=O)N1[END_SMILES] \\
+        \midrule
+        Technical Chemistry & 1.5 & Which of the following statements is true about the different types of ideal reactors? \\
+        & & A. In a batch reactor, the composition is uniformly mixed and remains the same throughout the reactor and at the exit \\
+        & & B. In a batch reactor, the fluid passes through the reactor with no mixing of earlier and later entering fluid \\
+        & & C. In a mixed flow reactor, the composition changes with time but is uniform everywhere within the reactor \\
+        & & D. In a plug flow reactor, the fluid moves in single flow through the reactor with no mixing and no overtaking \\
+        \midrule
+        Organic Chemistry & 15.5 & What is the reaction mechanism that describes the following reaction (represented using reaction SMILES) [START_RXNSMILES]CCCl.CO[Na]>>[Na]Cl.CCOC[END_RXNSMILES]? \\
+        & & A. $E_1$ \\
+        & & B. $E_{cb}$ \\
+        & & C. $S_N1$ \\
+        & & D. $S_N2$ \\
+        \midrule
+        Toxicity/Safety & 24.2 & What details pertaining to a hazardous substance can be located on a Material Safety Data Sheet (MSDS)? \\
+        & & A. All hazards regarding the material \\
+        & & B. Physical and chemical properties \\
+        & & C. Precautions for safe handling and storage \\
+        \midrule
+        Analytical Chemistry & 5.8 & Which of the following analytical methods is most appropriate for performing a survey analysis of a solid sample containing various metals? \\
+        & & A. X-ray fluorescence analysis \\
+        & & B. Differential pulse polarography \\
+        & & C. Flame-atomic absorption spectroscopy \\
+        & & D. Gas chromatography with flame ionization detector \\
+        & & E. Hydride generation atomic absorption spectroscopy \\
+        \midrule
+        Materials Science & 3.1 & For NMR analysis, you need to digest the MOF in a strong acid to remove the linker and leave the metal clusters intact. Why would one choose \\ce{HF} over \\ce{HCl} for this purpose? \\
+        & & A. \\ce{F-} forms a stable bonds to the metal ions \\
+        & & B. \\ce{HF} has a better water solubility than \\ce{HCl} \\
+        & & C. \\ce{HF} has a higher boiling point than \\ce{HCl} \\
+        & & D. \\ce{HF} is a weaker acid than \\ce{HCl} \\
+        \midrule
+        General Chemistry & 5.3 & Which of the following salts is an acidic salt? \\
+        & & A. \\ce{NH4Cl} \\
+        & & B. \\ce{Na2CO3} \\
+        & & C. \\ce{NaH2PO4} \\
+        & & D. \\ce{Zn(OH)Cl} \\
+        \midrule
+        Physical Chemistry & 6.3 & The Born-Oppenheimer (BO) approximation is widely used in computational chemistry, but its accuracy can vary depending on the system. Among the following options, for which system is the Born-Oppenheimer approximation likely to be least applicable? \\
+        & & A. \\ce{C60} \\
+        & & B. \\ce{CH4} \\
+        & & C. \\ce{Fe(CO)5} \\
+        & & D. \\ce{H2+} \\
+        & & E. \\ce{NaCl} \\
+        \midrule
+        Inorganic Chemistry & 3.3 & What is the oxidation number of the metal in the compound \\ce{[ZrF7]^{3-}}\\
+        \toprule
+        \textbf{Reasoning Type} & \textbf{Number of Questions} & \textbf{Example Question} \\
+        \midrule
+        Knowledge & 770 & Which of the following salts is an acidic salt? \\
+        & & A. \\
+        \midrule
+        Reasoning & 825 & How can the optical impact of quantum confinement on the electronic structure of a quantum dot be observed experimentally? \\
+        & & A. By measuring atomic force microscopy \\
+        & & B. By measuring fourier transform infrared spectroscopy \\
+        & & C. By measuring photoluminescence spectrum \\
+        & & D. By measuring the absorption spectroscopy \\
+        \midrule
+        Intuition & 1001 & Imagine an early virtual screening campaign setting (accounting for simple aspects such as oral availability and small molecular profile, but no other modalities such as covalency or bifunctionality). Which of the following two candidates would you prefer for further development? \\
+        & & A. [START_SMILES]CC1(C)Oc2ccc([N+](=O)[O-])cc2[C@@H](N2CCOCC2)[C@@H]1O[END_SMILES] \\
+        & & B. [START_SMILES]Cc1ccccc1N=C(S)N1CCC(NC(=O)c2ccco2)CC1[END_SMILES] \\
+        \midrule
+        Calculation & 91 & Given that the average molar mass of the polymer chains in this sample of poly(lactic acid) (PLA) is \\pu{595 g mol^{-1}} using end-group analysis, where \\pu{0.1619 g} of PLA was dissolved in \\pu{25 cm^3} of benzyl alcohol and titrated with \\pu{0.0400 mol dm^{-3}} \\ce{KOH} solution. The volume of \\ce{KOH} solution required to reach the endpoint was \\pu{6.81 cm^3}. What is the average number of monomer units in each polymer chain of this sample? \\
+        \bottomrule
+    \end{tabular}
+    \label{tab:chembench_corpus}
+\end{table*}
+
 % \subsection{Parsing verification}\label{sec:manually-verified-parsing}
 % For validating the parsing workflow, we randomly sampled four questions per topic and manually verified that the completions of the model were parsed correctly.
 

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -49,12 +49,11 @@ A substantial fraction, in contrast to other benchmarks, is open-ended.
     \script{plot_statistics.py}
 \end{figure}
 
-The corpus of the questions in  \chembench, as shown in \Cref{tab:chembench_corpus}, can be divided according to which topic they belong to or which type of knowledge is required to solve them correctly.
+The corpus of the questions in \chembench, as shown in \Cref{tab:chembench_corpus_topic}, can be divided according to which chemical topic they belong to.
 
 \begin{table*}[!t]
     \centering
-        \caption{Summary of \chembench question types.}
-    }
+        \caption{Examples for each of the topics considered in the evaluation of the \chembench corpus.}
     \begin{tabular}{p{2.7cm}cp{10cm}}
         \toprule
         \textbf{Question Type} & \textbf{\%} & \textbf{Example Questions}  \\ 
@@ -75,10 +74,12 @@ The corpus of the questions in  \chembench, as shown in \Cref{tab:chembench_corp
         & & C. $S_N1$ \\
         & & D. $S_N2$ \\
         \midrule
-        Toxicity/Safety & 24.2 & What details pertaining to a hazardous substance can be located on a Material Safety Data Sheet (MSDS)? \\
-        & & A. All hazards regarding the material \\
-        & & B. Physical and chemical properties \\
-        & & C. Precautions for safe handling and storage \\
+        Toxicity/Safety & 24.2 & Pindolol and propranolol are (relatively nonselective) antagonists at $\beta_1$- and $\beta_2$-adrenoceptors. However, pindolol is a partial agonist, whereas propranolol is a pure antagonist. What follows from this? \\
+        & & A. Pindolol has a greater therapeutic range than propranolol \\
+        & & B. Pindolol has a longer half-life than propranolol \\
+        & & C. Pindolol has intrinsic activity \\
+        & & D. Pindolol is more lipophilic than propranolol \\
+        & & E. Pindolol is more potent than propranolol \\
         \midrule
         Analytical Chemistry & 5.8 & Which of the following analytical methods is most appropriate for performing a survey analysis of a solid sample containing various metals? \\
         & & A. X-ray fluorescence analysis \\
@@ -107,11 +108,24 @@ The corpus of the questions in  \chembench, as shown in \Cref{tab:chembench_corp
         & & E. \\ce{NaCl} \\
         \midrule
         Inorganic Chemistry & 3.3 & What is the oxidation number of the metal in the compound \\ce{[ZrF7]^{3-}}\\
+    \end{tabular}
+    \label{tab:chembench_corpus_topic}
+\end{table*}
+
+In addition, as shown in \Cref{tab:chembench_corpus_cognitive} the \chembench corpus can be divided considering the different mental approaches needed to solve the questions.
+
+\begin{table*}[!t]
+    \centering
+        \caption{Examples for each of the mental approaches considered in the \chembench corpus.}
+    \begin{tabular}{p{2.7cm}cp{10cm}}
         \toprule
-        \textbf{Reasoning Type} & \textbf{Number of Questions} & \textbf{Example Question} \\
+        \textbf{Cognitive Type} & \textbf{Number of Questions} & \textbf{Example Question} \\
         \midrule
         Knowledge & 770 & Which of the following salts is an acidic salt? \\
-        & & A. \\
+        & & A. \\ce{NH4Cl} \\
+        & & B. \\ce{Na2CO3} \\
+        & & C. \\ce{NaH2PO4} \\
+        & & D. \\ce{Zn(OH)Cl} \\
         \midrule
         Reasoning & 825 & How can the optical impact of quantum confinement on the electronic structure of a quantum dot be observed experimentally? \\
         & & A. By measuring atomic force microscopy \\
@@ -126,7 +140,7 @@ The corpus of the questions in  \chembench, as shown in \Cref{tab:chembench_corp
         Calculation & 91 & Given that the average molar mass of the polymer chains in this sample of poly(lactic acid) (PLA) is \\pu{595 g mol^{-1}} using end-group analysis, where \\pu{0.1619 g} of PLA was dissolved in \\pu{25 cm^3} of benzyl alcohol and titrated with \\pu{0.0400 mol dm^{-3}} \\ce{KOH} solution. The volume of \\ce{KOH} solution required to reach the endpoint was \\pu{6.81 cm^3}. What is the average number of monomer units in each polymer chain of this sample? \\
         \bottomrule
     \end{tabular}
-    \label{tab:chembench_corpus}
+    \label{tab:chembench_corpus_cognitive}
 \end{table*}
 
 % \subsection{Parsing verification}\label{sec:manually-verified-parsing}

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -112,14 +112,14 @@ The corpus of the questions in \chembench, as shown in \Cref{tab:chembench_corpu
     \label{tab:chembench_corpus_topic}
 \end{table*}
 
-In addition, as shown in \Cref{tab:chembench_corpus_cognitive} the \chembench corpus can be divided considering the different mental approaches needed to solve the questions.
+In addition, as shown in \Cref{tab:chembench_corpus_cognitive} the \chembench corpus can be divided considering the different skills needed to solve the questions.
 
 \begin{table*}[!t]
     \centering
-        \caption{Examples for each of the mental approaches considered in the \chembench corpus.}
+        \caption{Examples for each of the required skills considered in the \chembench corpus.}
     \begin{tabular}{p{2.7cm}cp{10cm}}
         \toprule
-        \textbf{Cognitive Type} & \textbf{Number of Questions} & \textbf{Example Question} \\
+        \textbf{Required skills} & \textbf{Number of Questions} & \textbf{Example Question} \\
         \midrule
         Knowledge & 770 & Which of the following salts is an acidic salt? \\
         & & A. \\ce{NH4Cl} \\

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -49,7 +49,7 @@ A substantial fraction, in contrast to other benchmarks, is open-ended.
     \script{plot_statistics.py}
 \end{figure}
 
-The corpus of the questions in Chembench, as shown in \Cref{tab:chembench_corpus}, can be divided according to which topic they belong, or which type of knowledge is required in order to solve them correctly.
+The corpus of the questions in  \chembench, as shown in \Cref{tab:chembench_corpus}, can be divided according to which topic they belong to or which type of knowledge is required to solve them correctly.
 
 \begin{table*}[!t]
     \centering

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -53,7 +53,7 @@ The corpus of the questions in Chembench, as shown in \Cref{tab:chembench_corpus
 
 \begin{table*}[!t]
     \centering
-        \caption{Summary of ChemBench question types.
+        \caption{Summary of \chembench question types.}
     }
     \begin{tabular}{p{2.7cm}cp{10cm}}
         \toprule


### PR DESCRIPTION
Suggested by @kjappelbaum similar to the one in https://www.arxiv.org/pdf/2407.16931. 

Maybe it needs to be moved, the format corrected and the caption enhanced but I would like to know the thought on this first draft @lamalab-org/chem-bench

## Summary by Sourcery

Add a new table to the appendix that categorizes ChemBench questions by type, percentage, and provides example questions, enhancing the documentation of the ChemBench corpus.

New Features:
- Introduce a new table summarizing the ChemBench question types in the appendix.

Documentation:
- Add a detailed table in the appendix that categorizes ChemBench questions by type, percentage, and provides example questions.