### PR TITLE
fix: remove non-model-scores from plot

### DIFF
--- a/src/scripts/corpus_humanset_performace.py
+++ b/src/scripts/corpus_humanset_performace.py
@@ -6,6 +6,7 @@ from utils import (
     ONE_COL_GOLDEN_RATIO_HEIGHT_INCH,
     TWO_COL_WIDTH_INCH,
 )
+import re
 
 plt.style.use(scripts / "lamalab.mplstyle")
 
@@ -15,7 +16,8 @@ def plot_corpuses(complete_scores: dict, human_aligned_scores: dict, outname):
     models = sorted(
         complete_scores.keys(), key=lambda x: complete_scores[x], reverse=True
     )
-
+    # filter out models starting with a number
+    models = [model for model in models if not re.match(r"^\d", model)]
     complete_accuracies = [complete_scores[model] for model in models]
     human_aligned_accuracies = [human_aligned_scores[model] for model in models]
 
@@ -32,7 +34,7 @@ def plot_corpuses(complete_scores: dict, human_aligned_scores: dict, outname):
         x - bar_width / 2,
         complete_accuracies,
         bar_width,
-        label="ChemBench Corpus",
+        label="ChemBench",
         color="#a9dce3",
         alpha=0.9,
     )  # 007acc

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -229,7 +229,6 @@ An interesting observation is the significant impact of chemical preference task
     \caption{\textbf{
         Performance of the models on the \chembench corpus and \chembenchmini subset.} The bar plot shows the fraction of questions that were answered completely correctly, highlighting the relative performance of different models on both \chembench corpus and the \chembenchmini subset.
         We see that the model ranking remains fairly consistent across both sets}  
-    }
     \label{fig:performance_corpus_and_tiny}
     \script{corpus_humanset_performance.py}
 \end{figure}

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -227,7 +227,7 @@ An interesting observation is the significant impact of chemical preference task
     \centering
     \includegraphics{figures/corpus_human_comparison.pdf}
     \caption{\textbf{
-        Performance of the models on the \chembench corpus and \chembenchmini subset.} The bar plot shows the fraction of questions that were answered completely correctly, highlighting the relative performance of different models on both \chembench corpus and the \chembenchmini subset.
+        Performance of the models on the \chembench corpus and \chembenchmini subset.} The bar plot shows the fraction of questions that were answered completely correctly, highlighting the relative performance of different models on both the \chembench corpus and the \chembenchmini subset.
         We see that the model ranking remains fairly consistent across both sets}  
     \label{fig:performance_corpus_and_tiny}
     \script{corpus_humanset_performance.py}

--- a/src/tex/preamble.tex
+++ b/src/tex/preamble.tex
@@ -49,7 +49,7 @@
 \definecolor{halfgray}{gray}{0.55}
 \renewcommand\labelitemi{\color{halfgray}$\bullet$}
 \newcommand{\chembench}{ChemBench\xspace}
-\newcommand{\chembench}{ChemBench-mini\xspace}
+\newcommand{\chembenchmini}{ChemBench-Mini\xspace}
 %\usepackage{kpfonts}
 
 


### PR DESCRIPTION
## Summary by Sourcery

Fix the plot to exclude non-model scores by filtering out models starting with a number, update plot labels for clarity, and correct minor formatting issues in the documentation.

Bug Fixes:
- Remove non-model scores from the plot by filtering out models starting with a number.

Enhancements:
- Update the label in the plot from 'ChemBench Corpus' to 'ChemBench' for clarity.

Documentation:
- Correct minor formatting issues in the appendix section of the documentation.