### PR TITLE
fix affiliations from feedback

### DIFF
--- a/src/tex/authors.tex
+++ b/src/tex/authors.tex
@@ -48,7 +48,7 @@
 \credit{Santiago~Miret}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
 \credit{Jan Matthias Peschel}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
 \credit{Michael Ringleb}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
-\credit{Nicole Roesner}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
+\credit{Nicole~C.~Roesner}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
 \credit{Johanna Schreiber}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
 \credit{Ulrich~S.~Schubert}{0,0,0,1,0,0,0,0,0,0,0,0,0,1}
 \credit{Leanne M. Stafast}{0,1,0,0,0,0,0,0,0,0,0,0,0,1}
@@ -78,10 +78,10 @@
 \author[3]{María~Victoria~Gil~\orcidlink{0000-0003-4894-4660}}
 \author[ ]{Christina~Glaubitz~\orcidlink{0000-0003-3412-0548}}
 \author[1]{Maximilian~Greiner}
-\author[1]{Caroline~T.~Holick~\orcidlink{0009-0000-1724-2725}}
-\author[1]{Tim~Hoffmann~\orcidlink{0009-0004-0230-6115}}
+\author[14]{Caroline~T.~Holick~\orcidlink{0009-0000-1724-2725}}
+\author[14]{Tim~Hoffmann~\orcidlink{0009-0004-0230-6115}}
 \author[1]{Abdelrahman~Ibrahim~\orcidlink{0009-0003-1460-4710}}
-\author[1]{Lea~C.~Klepsch~\orcidlink{0009-0009-3849-1670}}
+\author[14]{Lea~C.~Klepsch~\orcidlink{0009-0009-3849-1670}}
 \author[1]{Yannik~Köster~\orcidlink{0000-0002-9125-3067}}
 \author[11, 12]{Fabian~Alexander~Kreth~\orcidlink{0000-0002-5968-8706}}
 \author[1]{Jakob~Meyer}
@@ -119,7 +119,7 @@
 \affil[13]{Intel Labs}
 \affil[14]{Jena Center for Soft Matter (JCSM), Friedrich Schiller University Jena, Philosophenweg 7, 07743 Jena, Germany}
 
-\affil[14]{Theoretical Chemistry, Technische Universität Dresden, Dresden 01062, Germany}
+\affil[15]{Theoretical Chemistry, Technische Universität Dresden, Dresden 01062, Germany}
 \affil[16]{OpenBioML.org}
 \affil[17]{Stability.AI}
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct author affiliations and names based on feedback.