### PR TITLE
feat: add comments about no data from benchs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -194,6 +194,7 @@ rule question_counts:
       "src/tex/output/question_count_per_dir/json_file_counts_electron_counts.txt",
       "src/tex/output/question_count_per_dir/json_file_counts_chem_chem_comp.txt",
       "src/tex/output/question_count_per_dir/json_file_counts_materials_compatibility.txt",
+      "src/tex/output/question_count_per_dir/json_file_counts_preference.txt",
     ]
   script: "src/scripts/count_json_files.py"
 

--- a/src/scripts/count_json_files.py
+++ b/src/scripts/count_json_files.py
@@ -101,6 +101,18 @@ def main():
 
     logger.info(f"Number of json files in pictograms: {num_pictograms}")
 
+    num_preference = len(
+        glob(
+            os.path.join(
+                chembench_repo, "data", "preference", "*.json"
+            )
+        )
+    )
+
+    with open(output_path / "json_file_counts_preference.txt", "w") as f:
+        f.write(f"{num_preference}" + "\endinput")
+
+    logger.info(f"Number of json files about chemical preference: {num_preference}")
 
 if __name__ == "__main__":
     main()

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -50,8 +50,8 @@ Reviewers also solved the questions to verify the answers. They also performed w
 
 In addition to the manual review, we also performed automated checks to ensure the quality of the questions. The schemas, Latex templating, and other formatting aspects are checked automatically using GitHub Actions.
 
-While adding questions from existing benchmarks seemed to be another good source of semi-automatically generated data, we prioritize diversity of the data and avoiding data contamination while addressing the guidelines above and in \Cref{sec:desired-properties}.
-Therefore, we decided to not include questions from other previous published chemistry-focused benchmarks into the \chembench corpus.
+While adding questions from existing benchmarks might seem to be another good source of semi-automatically generated data, we prioritized the diversity of the data and avoided data contamination while addressing the guidelines above and in \Cref{sec:desired-properties}.
+However, even though we decided not to include questions from other previously published chemistry-focused benchmarks into the \chembench corpus, the framework is flexible enough to be readily extended with questions from other benchmarks.
 
 \subsubsection{Composition}
 

--- a/src/tex/appendix.tex
+++ b/src/tex/appendix.tex
@@ -50,6 +50,9 @@ Reviewers also solved the questions to verify the answers. They also performed w
 
 In addition to the manual review, we also performed automated checks to ensure the quality of the questions. The schemas, Latex templating, and other formatting aspects are checked automatically using GitHub Actions.
 
+While adding questions from existing benchmarks seemed to be another good source of semi-automatically generated data, we prioritize diversity of the data and avoiding data contamination while addressing the guidelines above and in \Cref{sec:desired-properties}.
+Therefore, we decided to not include questions from other previous published chemistry-focused benchmarks into the \chembench corpus.
+
 \subsubsection{Composition}
 
 \Cref{fig:cb_humanset} shows the distribution of topics and required skills in the human subset of the \chembench corpus.

--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -262,14 +262,12 @@ Questions were added via Pull Requests on our GitHub repository and only merged 
 
 To ensure that the questions do not enter a training dataset, we use the same canary string as the BigBench project.
 This requires that \Gls{llm} developers filter their training dataset for this canary string.\autocite{openai2024gpt4, srivastava2022beyond}
-Related to this, in order to avoid data contamination we did not include data from other chemistry-focused benchmarks.
-However, if in the future we decide to include them, it should not be difficult to automatically do it.
 
 
 
 \begin{table}[!h]
     \centering
-    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus. The chemical preference questions are the main corpus of the semi-automatically generated group with 1001 questions of the total 1752.}
+    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus. Note that the chemical preference questions are the main corpus of the semi-automatically generated group with 1001 questions of the total 1752.}
     \variable{output/sources_table.tex}
     \label{tab:sources}
 \end{table}

--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -262,12 +262,14 @@ Questions were added via Pull Requests on our GitHub repository and only merged 
 
 To ensure that the questions do not enter a training dataset, we use the same canary string as the BigBench project.
 This requires that \Gls{llm} developers filter their training dataset for this canary string.\autocite{openai2024gpt4, srivastava2022beyond}
+Related to this, in order to avoid data contamination we did not include data from other chemistry-focused benchmarks.
+However, if in the future we decide to include them, it should not be difficult to automatically do it.
 
 
 
 \begin{table}[!h]
     \centering
-    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus.}
+    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus. The chemical preference questions are the main corpus of the semi-automatically generated group with 1001 questions of the total 1752.}
     \variable{output/sources_table.tex}
     \label{tab:sources}
 \end{table}

--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -267,7 +267,7 @@ This requires that \Gls{llm} developers filter their training dataset for this c
 
 \begin{table}[!h]
     \centering
-    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus. Note that the chemical preference questions are the main corpus of the semi-automatically generated group with 1001 questions of the total 1752.}
+    \caption{\textbf{Overview of sources of the curated questions}. The table provides an overview of the types of sources the questions have been curated from. Detailed sources are available in the source data on GitHub. Questions without source have been curated completely from scratch. Questions based on lecture notes or URL have been curated based on content presented in those resources. All questions have been rephrased, annotated, and reviewed before being added to the corpus. Note that the chemical preference questions are the main corpus of the semi-automatically generated group with \variable{output/question_count_per_dir/json_file_counts_preference.txt} questions of the total \variable{output/automatically_generated.txt}.}
     \variable{output/sources_table.tex}
     \label{tab:sources}
 \end{table}


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add comments explaining the exclusion of data from other chemistry-focused benchmarks to avoid data contamination.